### PR TITLE
Fixes for fmod console

### DIFF
--- a/src/editor/command_input.cpp
+++ b/src/editor/command_input.cpp
@@ -1,4 +1,5 @@
 #ifdef TOOLS_ENABLED
+#include "classes/input_event_key.hpp"
 #include "command_input.h"
 #include "core/math.hpp"
 #include "core/object.hpp"
@@ -7,7 +8,6 @@
 #include <classes/editor_interface.hpp>
 #include <classes/global_constants.hpp>
 #include <classes/input_event.hpp>
-#include "classes/input_event_key.hpp"
 using namespace FmodGodot;
 using namespace godot;
 #define EDSCALE EditorInterface::get_singleton()->get_editor_scale()
@@ -17,6 +17,7 @@ void CommandInput::_bind_methods()
 }
 CommandInput::CommandInput()
 {
+    set_fit_content_height_enabled(true);
     history.reserve(history_length);
 }
 void CommandInput::history_push(const String &command)
@@ -27,10 +28,11 @@ void CommandInput::history_push(const String &command)
     }
     history.push_back(command);
 }
-void CommandInput::update_height()
+void FmodGodot::CommandInput::_enter_tree()
 {
-    set_custom_minimum_size(Vector2(EDSCALE * 150, get_line_height() * Math::min(1, get_line_count())));
+    set_line_wrapping_mode(TextEdit::LINE_WRAPPING_BOUNDARY);
 }
+
 void CommandInput::_gui_input(const Ref<InputEvent> &event)
 {
     if (event->is_action_pressed("ui_up"))
@@ -42,7 +44,7 @@ void CommandInput::_gui_input(const Ref<InputEvent> &event)
         }
         else
         {
-            set_text(history[history_index]);
+            set_text(history[history.size() - history_index - 1]);
         }
         accept_event();
     }
@@ -55,27 +57,28 @@ void CommandInput::_gui_input(const Ref<InputEvent> &event)
         }
         else
         {
-            set_text(history[history_index]);
+            set_text(history[history.size() - history_index - 1]);
         }
         accept_event();
     }
     Ref<InputEventKey> key = event;
     if (key.is_valid() && key->is_pressed())
     {
-        if (key->get_keycode_with_modifiers() == (KEY_ENTER | KEY_SHIFT))
+        if (key->get_keycode_with_modifiers() == (Key)(KEY_ENTER | KEY_MASK_SHIFT))
         {
-            update_height();
+            insert_text_at_caret("\n");
+            accept_event();
         }
-        else if (KEY_ENTER == key->get_keycode() || KEY_ENTER == key->get_physical_keycode())
+        else if (key->get_keycode_with_modifiers() == KEY_ENTER)
         {
             if (get_text().strip_edges().is_empty())
             {
                 return;
             }
             emit_signal("command_submitted", get_text());
-            if (history_index != -1 && get_text() == history[history_index])
+            if (history_index != -1 && get_text() == history[history.size() - history_index - 1])
             {
-                history.remove_at(history_index);
+                history.remove_at(history.size() - history_index - 1);
             }
             history_push(get_text());
             history_index = -1;
@@ -84,4 +87,23 @@ void CommandInput::_gui_input(const Ref<InputEvent> &event)
         }
     }
 }
+godot::PackedStringArray FmodGodot::CommandInput::get_history() const
+{
+    PackedStringArray arr;
+    arr.resize(history.size());
+    for (int i = 0; i < history.size(); i++)
+    {
+        arr[i] = history[i];
+    }
+    return arr;
+}
+void FmodGodot::CommandInput::load_history(const PackedStringArray &arr)
+{
+    history.clear();
+    history.reserve(history_length);
+    for (int i = 0; i < arr.size(); i++)
+    {
+        history.push_back(arr[i]);
+    }
+};
 #endif

--- a/src/editor/command_input.h
+++ b/src/editor/command_input.h
@@ -1,9 +1,10 @@
 #pragma once
+#include "variant/packed_string_array.hpp"
 #ifdef TOOLS_ENABLED
 #include "classes/text_edit.hpp"
 #include "classes/wrapped.hpp"
-#include <classes/input_event.hpp>
 #include "templates/local_vector.hpp"
+#include <classes/input_event.hpp>
 namespace FmodGodot
 {
 using namespace godot;
@@ -22,8 +23,10 @@ class CommandInput : public TextEdit
   public:
     CommandInput();
     void history_push(const String &command);
-    void update_height();
+    void _enter_tree() override;
     void _gui_input(const Ref<InputEvent> &event) override;
+    PackedStringArray get_history() const;
+    void load_history(const PackedStringArray &arr);
 };
 } // namespace FmodGodot
 #endif

--- a/src/editor/fmod_console.cpp
+++ b/src/editor/fmod_console.cpp
@@ -1,10 +1,11 @@
+#include "command_input.h"
 #ifdef TOOLS_ENABLED
-#include "fmod_console.h"
 #include "classes/config_file.hpp"
 #include "classes/h_flow_container.hpp"
 #include "classes/line_edit.hpp"
 #include "classes/script_editor.hpp"
 #include "classes/v_box_container.hpp"
+#include "fmod_console.h"
 #include "fmod_script_client.h"
 #include "variant/callable_method_pointer.hpp"
 #include "variant/packed_string_array.hpp"
@@ -94,7 +95,6 @@ void FmodConsole::_update_theme()
     button->set_custom_minimum_size(Vector2(button->get_minimum_size().x * EDSCALE, 0));
 
     clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
-    collapse_button->set_button_icon(get_editor_theme_icon(SNAME("CombineLines")));
 
     theme_cache.error_color = get_theme_color(SNAME("error_color"), EditorStringName(Editor));
     theme_cache.error_icon = get_editor_theme_icon(SNAME("Error"));
@@ -135,12 +135,6 @@ void FmodGodot::FmodConsole::_bind_methods()
 {
 }
 
-void FmodConsole::_set_collapse(bool p_collapse)
-{
-    collapse = p_collapse;
-    _rebuild_log();
-}
-
 void FmodConsole::_save_layout_to_config(const Ref<ConfigFile> &p_config, const String &p_section) const
 {
     for (const KeyValue<MessageType, LogFilter *> &E : type_filter_map)
@@ -148,7 +142,7 @@ void FmodConsole::_save_layout_to_config(const Ref<ConfigFile> &p_config, const 
         p_config->set_value(p_section, "_editor_log_filter_" + itos(E.key), E.value->is_active());
     }
 
-    p_config->set_value(p_section, "_editor_log_collapse", collapse);
+    p_config->set_value(p_section, "_command_history", input->get_history());
 }
 
 void FmodConsole::_load_layout_from_config(const Ref<ConfigFile> &p_config, const String &p_section)
@@ -159,8 +153,7 @@ void FmodConsole::_load_layout_from_config(const Ref<ConfigFile> &p_config, cons
     {
         E.value->set_active(p_config->get_value(p_section, "_editor_log_filter_" + itos(E.key), true));
     }
-    collapse_button->set_pressed(p_config->get_value(p_section, "_editor_log_collapse", false));
-
+    input->load_history(p_config->get_value(p_section, "_command_history", PackedStringArray({})));
     is_loading_state = false;
 }
 void FmodGodot::FmodConsole::_set_fmod_script_client(FmodScriptClient *p_client)
@@ -216,7 +209,7 @@ void FmodConsole::_process_message(const String &p_msg, MessageType p_type, bool
         LogMessage &previous = messages.write[messages.size() - 1];
         previous.count++;
 
-        _add_log_line(previous, collapse);
+        _add_log_line(previous);
     }
     else
     {
@@ -262,9 +255,9 @@ void FmodGodot::FmodConsole::_command_submitted(const String &command)
     {
         add_message(text.substr(8), MessageType::MSG_TYPE_ERROR);
     }
-    else if (text.begins_with("warning():"))
+    else if (text.begins_with("warn():"))
     {
-        add_message(text.substr(10), MessageType::MSG_TYPE_WARNING);
+        add_message(text.substr(7), MessageType::MSG_TYPE_WARNING);
     }
     else
     {
@@ -289,22 +282,11 @@ void FmodConsole::_rebuild_log()
     for (start_message_index = messages.size() - 1; start_message_index >= 0; start_message_index--)
     {
         LogMessage msg = messages[start_message_index];
-        if (collapse)
+        for (int i = 0; i < msg.count; i++)
         {
             if (_check_display_message(msg))
             {
                 line_count++;
-            }
-        }
-        else
-        {
-            // If not collapsing, log each instance on a line.
-            for (int i = 0; i < msg.count; i++)
-            {
-                if (_check_display_message(msg))
-                {
-                    line_count++;
-                }
             }
         }
         if (line_count >= line_limit)
@@ -322,19 +304,10 @@ void FmodConsole::_rebuild_log()
     {
         LogMessage msg = messages[msg_idx];
 
-        if (collapse)
+        for (int i = initial_skip; i < msg.count; i++)
         {
-            // If collapsing, only log one instance of the message.
+            initial_skip = 0;
             _add_log_line(msg);
-        }
-        else
-        {
-            // If not collapsing, log each instance on a line.
-            for (int i = initial_skip; i < msg.count; i++)
-            {
-                initial_skip = 0;
-                _add_log_line(msg);
-            }
         }
     }
 }
@@ -408,14 +381,6 @@ void FmodConsole::_add_log_line(LogMessage &p_message, bool p_replace_previous)
     {
         _set_dock_tab_icon(theme_cache.disconnected_icon);
     }
-    // If collapsing, add the count of this message in bold at the start of the line.
-    if (collapse && p_message.count > 1)
-    {
-        log->push_bold();
-        log->add_text(vformat("(%s) ", itos(p_message.count)));
-        log->pop();
-    }
-
     // Note that errors and warnings only support BBCode in the file part of the message.
     if (p_message.type == MSG_TYPE_STD_RICH || p_message.type == MSG_TYPE_ERROR || p_message.type == MSG_TYPE_WARNING)
     {
@@ -501,17 +466,6 @@ FmodConsole::FmodConsole()
     EditorInterface::get_singleton()->get_editor_settings()->get_shortcut("editor/clear_output");
     bottom_hf->add_child(clear_button);
 
-    // Collapse.
-    collapse_button = memnew(Button);
-    collapse_button->set_theme_type_variation("BottomPanelButton");
-    collapse_button->set_focus_mode(FOCUS_ACCESSIBILITY);
-    collapse_button->set_tooltip_text(
-        tr("Collapse duplicate messages into one log entry. Shows number of occurrences."));
-    collapse_button->set_toggle_mode(true);
-    collapse_button->set_pressed(false);
-    collapse_button->connect(SceneStringName(toggled), callable_mp(this, &FmodConsole::_set_collapse));
-    bottom_hf->add_child(collapse_button);
-
     // Search box
     input = memnew(CommandInput);
     input->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -545,7 +499,7 @@ FmodConsole::FmodConsole()
 
     LogFilter *input_filter = memnew(LogFilter(MSG_TYPE_INPUT));
     input_filter->initialize_button(tr("Editor Messages"), tr("Toggle visibility of sent commands."),
-                                     callable_mp(this, &FmodConsole::_set_filter_active));
+                                    callable_mp(this, &FmodConsole::_set_filter_active));
     hbox->add_child(input_filter->toggle_button);
     type_filter_map.insert(MSG_TYPE_INPUT, input_filter);
 }

--- a/src/editor/fmod_console.h
+++ b/src/editor/fmod_console.h
@@ -121,9 +121,6 @@ class FmodConsole : public EditorDock
 
     Button *clear_button = nullptr;
 
-    Button *collapse_button = nullptr;
-    bool collapse = false;
-
     CommandInput *input = nullptr;
     FmodScriptClient *client = nullptr;
 
@@ -143,8 +140,6 @@ class FmodConsole : public EditorDock
     void _reset_message_counts();
     void _set_dock_tab_icon(Ref<Texture2D> p_icon);
     void _command_submitted(const String &command);
-
-    void _set_collapse(bool p_collapse);
 
     void _update_theme();
     void _editor_settings_changed();


### PR DESCRIPTION
- warnings will now be properly displayed in fmod console
- multiline input is now possible
- command history is now saved
- arrows key now correctly search through command history